### PR TITLE
Fix react-snap localhost asset URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "clean": "rm -rf build/",
     "build": "vite build",
-    "postbuild": "react-snap",
+    "postbuild": "react-snap && perl -0pi -e 's#http://localhost:45678/#./#g' build/*.html",
     "preview": "vite preview",
     "format": "prettier src/ --check",
     "format:fix": "prettier -w src/ --check",


### PR DESCRIPTION
ビルド後のHTMLにローカルへのパスが含まれることの修正です。

デモページでも確認したところ、`https://denkiwakame.github.io/academic-project-template/` に `<link href="http://localhost:45678/assets/theme-DQ6bdJ38.css" rel="stylesheet" crossorigin="">` が含まれていました。

この修正でも動くには動きますが、ややアドホックな感もあるため、取り入れずクローズでも全然問題ありません。
取り急ぎご報告まで。